### PR TITLE
Add an option to choose property in package.json

### DIFF
--- a/src/scripts-help.mjs
+++ b/src/scripts-help.mjs
@@ -13,6 +13,11 @@ function main() {
       type: 'string',
       short: 'w',
     },
+    'key': {
+      type: 'string',
+      short: 'k',
+      default: 'scripts-help',
+    },
   };
   const parsed = util.parseArgs({options});
   let descColWidth = Number.parseInt(parsed.values['desc-col-width']);
@@ -39,7 +44,7 @@ function main() {
       continue;
     }
     const row = [esc(ansi.Bold, scriptName)];
-    const scriptHelp = pkg['scripts-help'][scriptName];
+    const scriptHelp = pkg[parsed.values['key']][scriptName];
     if (scriptHelp) {
       row.push(scriptHelp.trim());
     } else {

--- a/src/scripts-help.mjs
+++ b/src/scripts-help.mjs
@@ -13,9 +13,9 @@ function main() {
       type: 'string',
       short: 'w',
     },
-    'key': {
+    'property': {
       type: 'string',
-      short: 'k',
+      short: 'p',
       default: 'scripts-help',
     },
   };
@@ -44,7 +44,7 @@ function main() {
       continue;
     }
     const row = [esc(ansi.Bold, scriptName)];
-    const scriptHelp = pkg[parsed.values['key']][scriptName];
+    const scriptHelp = pkg[parsed.values['property']][scriptName];
     if (scriptHelp) {
       row.push(scriptHelp.trim());
     } else {


### PR DESCRIPTION
For interoperability with [npm-scripts-info](https://github.com/srph/npm-scripts-info) package

Example `package.json` file:

```json
{
  "scripts-info": {
    "tsc": "Compile the TypeScript to JavaScript.",
    "tscwatch": "Watch the TypeScript source code and compile it incrementally when and if there are changes.",
    "serve": "Serve the generated website via a local server."
  }
}
```

Command:

```shell
npx @rauschma/scripts-help -p scripts-info
```